### PR TITLE
「東京都 区市町村別詳細 新型コロナウイルス陽性者数」サイト追記のご提案

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@
 [東京都のサイトから派生した各都道府県の最新感染動向](https://github.com/tokyo-metropolitan-gov/covid19/blob/development/FORKED_SITES.md)  
 東京都のリポジトリからforkされた各都道府県サイトの一覧
 
+
+[東京都 区市町村別詳細 新型コロナウイルス陽性者数](https://nobukuni-hyakutake.github.io/covid19tokyo/)[(GitHub:Nobukuni-Hyakutake/covid19tokyo)](https://github.com/Nobukuni-Hyakutake/covid19tokyo)<br>
+個人の発信。区市町村別の分布マップと推移グラフあり
+
+
 以下は、個人的に気にしている都道府県の感染動向へのリンク（その他は、上記のリンク先を参照）
 
 [愛知県内の最新感染動向](https://stopcovid19.code4.nagoya/)[(GitHub:code4nagoya/covid19)](https://github.com/code4nagoya/covid19)  
 [三重県内の最新感染動向](https://covid19-mie.netlify.com/)[(GitHub:FlexiblePrintedCircuits/covid19-mie)](https://github.com/FlexiblePrintedCircuits/covid19-mie)  
-
 
 #### 新型コロナウイルス対策サイト立ち上げのための技術的情報
 [東京都 新型コロナウイルス対策サイトへの貢献方法を解説](https://qiita.com/FPC_COMMUNITY/items/b9cc072813dc2231b2b2)  


### PR DESCRIPTION
## Purpose

サイトの追記

## Effect

このページを見た人にサイトの存在をお知らせする

## Test

-

## Test Environment

-

### Hardware

-

### Software(Library)

-

## Memo
初めまして。Qiita記事のリンクから、こちらのページを興味深く拝見しました。
私の管理しているサイトを、このように一覧に追加していただくことは可能でしょうか。ご検討よろしくお願いします。
特に東京都内の区市町村別の分布マップは、どこのサイトにも無いユニークなものとなっております。